### PR TITLE
部屋/ベッド番号, 見守り対象者名, 異常検出動作, 検知画像(検知時), 検知画像(検知直前) 追加

### DIFF
--- a/docusaurus/static/swagger/v2/microservice.yaml
+++ b/docusaurus/static/swagger/v2/microservice.yaml
@@ -91,7 +91,20 @@ paths:
           description: 該当イベント
           content:
             application/json:
-              schema: { $ref: '#/components/schemas/Incident' }
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Incident'
+                  - type: object
+                    properties:
+                      pictuers:
+                        type: object
+                        properties:
+                          pictureAtDetection:
+                            type: string
+                            description: "検知画像(検知時) base64形式"
+                          pictureBeforeDetection:
+                            type: string
+                            description: "検知画像(検知直前) base64形式"
 
     patch:
       tags: [Incident]
@@ -201,13 +214,25 @@ paths:
           schema: { type: string }
       responses:
         '200':
-          description: 履歴リスト
+          description: 履歴リスト（各履歴に部屋/ベッド名称または番号、見守り対象者名、異常検出動作を含む）
           content:
             application/json:
               schema:
                 type: array
-                items: { $ref: '#/components/schemas/Action' }
-
+                items: 
+                  allOf:
+                    - $ref: '#/components/schemas/Action'
+                    - type: object
+                      properties:
+                        roomBedNameOrNumber:
+                          type: string
+                          description: "部屋またはベッドの名前・番号"
+                        personName:
+                          type: string
+                          description: "見守り対象者名"
+                        incidentDetectionType:
+                          type: string
+                          description: "異常検出動作"
     post:
       tags: [Action]
       summary: 対応登録/進捗切替


### PR DESCRIPTION
# dodoAI リンク
- https://dodoai.cacidentity.com/main/restore/c97e670b-3ede-4266-beb0-0c3cc2cce918

- Prompt1
```
既存のAPI定義に、以下の変更を加えてください

# 変更内容
- 対象API：GET /incidents/{incidentId}/actions 
- 変更内容：Response パラメータに、以下の2つを表すパラメータを追加してください。
- 1. "見守り対象者名"
- 2. "異常検出動作"
- データ型はいずれも"string"でお願いします。


# 注意事項
変更は上記、および影響を受ける他のAPIのみとし、基本的には他の箇所は現状を維持してください。
また、アウトプットは、変更箇所のみではなく、全てのAPIを定義含めてアウトプットしてください。

```

- Prompt2
```
既存のAPI定義に、以下の変更を加えてください

# 変更内容
- 対象API：GET /incidents/{incidentId}
- 変更内容：Responses パラメータに、"pictuers"階層を追加し、その中に以下の2つを表すパラメータを追加してください。
- 1. "検知画像(検知時)"
- 2. "検知画像(検知直前)"
- データ型はいずれも、base64形式を格納するための"string"型でお願いします。


# 注意事項
変更は上記、および影響を受ける他のAPIのみとし、基本的には他の箇所は現状を維持してください。
また、アウトプットは、変更箇所のみではなく、全てのAPIを定義含めてアウトプットしてください。
```
