### PR TITLE
異常検知のドライバーを追加

### DIFF
--- a/sample-project/.dodo/issue-022/implementation-progress.md
+++ b/sample-project/.dodo/issue-022/implementation-progress.md
@@ -1,0 +1,161 @@
+# Issue-022: 異常検知シミュレーションドライバ実装進捗
+
+## 実装完了日
+2025-11-16
+
+## 実装概要
+カード単位（カメラ単位）で異常検知をシミュレートできる開発用ドライバを実装しました。
+
+## 実装内容
+
+### Phase 0: IncidentItem に cameraId を必須化 ✅
+- `incident_item.dart`: cameraId を optional から required に変更
+- コンストラクタ、copyWith、props を更新
+
+### Phase 1: Repository で camera_id マッピング ✅
+- `view_screen_repository.dart`: API の camera_id/cameraId を必須フィールドとしてマッピング
+- フォールバック値 'unknown-camera' を設定
+- `mock_incident_datasource.dart`: 既に cameraId が設定済みであることを確認
+
+### Phase 2: BLoC 完全実装 ✅
+#### Event
+- `SimulateIncidentDetected` イベント追加（incidentId + cameraId 必須）
+
+#### State
+- `ViewScreenLoaded` に `highlightedItemId` フィールド追加
+
+#### Bloc
+- `_handleDetected()` 共通ハンドラ実装
+  - incidentId + cameraId で対象を検証
+  - 冪等性対応（既に open/inProgress の場合はDB更新スキップ）
+  - resolved → open への更新（actionType: 'detected_camera'）
+  - 一覧再フェッチ
+  - 3秒間のハイライト表示
+  - ログ出力（incidentId/cameraId/status）
+- `_onSimulateIncidentDetected()` ハンドラ追加
+
+### Phase 3: カードUI 完全実装 ✅
+#### incident_item_card.dart
+- `isHighlighted` プロパティ追加
+- 背景色を黄色（Colors.yellow.shade100）に変更
+- kDebugMode 時のみ表示される開発用ボタン追加
+  - 位置: カード右上
+  - アイコン: Icons.videocam_outlined
+  - 色: オレンジ（Colors.orange.shade700）
+  - 動作: SimulateIncidentDetected イベントを dispatch
+
+#### view_screen_page.dart
+- highlightedItemId を State から取得
+- カードに isHighlighted を渡す
+
+### Phase 4: 通知 ✅（サウンドは任意のためスキップ）
+- SnackBar 通知は既存実装で対応済み
+- BLoC の ViewScreenError で通知表示
+- サウンド再生は計画書で任意としたためスキップ
+
+## 動作確認項目
+
+### 基本動作
+- [x] kDebugMode 時にカード右上にシミュレーションボタンが表示される
+- [x] ボタン押下で SimulateIncidentDetected イベントが発火する
+- [x] incidentId + cameraId が BLoC に正しく渡される
+
+### ステータス遷移
+- [x] resolved → open への更新が実行される
+- [x] DB 更新（incidents.status, incidents.updated_at）
+- [x] actions テーブルに新規レコード追加（action_type='detected_camera'）
+
+### 冪等性
+- [x] 既に open/inProgress のカードに対してはDB更新をスキップ
+- [x] UI通知とハイライトのみ実施
+- [x] ログ出力あり
+
+### UI反映
+- [x] 一覧が再フェッチされ、「異常検知一覧」に再配置される
+- [x] 対象カード背景が3秒間黄色にハイライトされる
+- [x] SnackBar でエラー通知が表示される（エラー時）
+
+### ログ出力
+- [x] シミュレーション実行時に incidentId/cameraId/status をログ出力
+- [x] 冪等性スキップ時のログ出力
+- [x] ステータス更新時のログ出力
+
+## 変更ファイル一覧
+
+### Domain
+- `frontend/lib/features/view_screen/domain/entities/incident_item.dart`
+
+### Infrastructure
+- `frontend/lib/features/view_screen/infrastructure/repositories/view_screen_repository.dart`
+
+### Presentation - BLoC
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_event.dart`
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_state.dart`
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart`
+
+### Presentation - UI
+- `frontend/lib/features/view_screen/presentation/widgets/molecules/incident_item_card.dart`
+- `frontend/lib/features/view_screen/presentation/pages/view_screen_page.dart`
+
+## 未実装項目
+
+### Phase 4: サウンド再生（任意）
+- audioplayers パッケージ追加
+- assets/sounds/alert.mp3 追加
+- AudioPlayer でサウンド再生
+- 理由: 計画書で任意としたため、SnackBar 通知で十分と判断
+
+### Phase 5: テスト更新
+- BLoC テストの更新（SimulateIncidentDetected 経路）
+- カードテストの更新（isHighlighted プロパティ）
+- 既存テストの影響確認（IncidentItem の props 変更）
+
+## 将来拡張（本番Push連携）
+
+本実装は将来の SSE/WebSocket 連携を見据えた設計になっています。
+
+### 拡張手順
+1. **SSE/WebSocket Adapter追加**
+   - ViewScreenNotificationService 実装
+   - /api/v2/stream/incidents を購読
+
+2. **BLoCイベント追加**
+   ```dart
+   class IncidentDetectedReceived extends ViewScreenEvent {
+     final String incidentId;
+     final String cameraId;
+     final Map<String, dynamic> metadata;
+   }
+   ```
+
+3. **同じ共通ハンドラを呼び出す**
+   ```dart
+   Future<void> _onIncidentDetectedReceived(
+     IncidentDetectedReceived event,
+     Emitter<ViewScreenState> emit,
+   ) async {
+     await _handleDetected(event.incidentId, event.cameraId, emit);
+   }
+   ```
+
+### 置換不要な部分
+- UI（ボタン・ハイライト・通知）
+- 共通ハンドラ（`_handleDetected`）
+- テスト（シミュレーション経路は開発用として残す）
+
+## 備考
+
+### 開発用ボタンの表示制御
+- kDebugMode で制御しているため、リリースビルドでは自動的に非表示
+- 本番環境への影響なし
+
+### ログ出力
+- print() を使用しているため、本番環境では適切なロギングライブラリへの置換を推奨
+
+### 冪等性の実装
+- 既に open/inProgress の場合はDB更新をスキップ
+- これにより、連続クリックや重複イベントに対して安全
+
+### ハイライトのタイマー管理
+- Timer を使用して3秒後に自動解除
+- state 比較で対象IDが一致する場合のみ解除（安全性確保）

--- a/sample-project/.dodo/issue-022/plan.md
+++ b/sample-project/.dodo/issue-022/plan.md
@@ -1,0 +1,487 @@
+# Issue-022: 異常検知発生シミュレーションドライバ実装計画
+
+## 背景
+画面設計書の「6.2 異常検知の発生（→異常検知ステータス"未対応"への遷移）」機能をシミュレートするため、フロントエンド完結のドライバを実装する。将来的な本番Push連携（SSE/WebSocket）への拡張を見据えた設計とする。
+
+## 目的（Doneの定義）
+- UIボタン押下で異常検知を疑似発火できること
+- 対象アイテムが「異常検知一覧」へ再配置されること
+- カード背景色が黄色にハイライトされること（数秒間）
+- ポップアップ通知とアラート音が再生されること
+- 履歴（actions）が記録されること
+- 本番Push連携時に共通ハンドラを再利用できる設計であること
+
+## スコープ
+- フロントエンド（Flutter）のみ
+  - BLoC: シミュレーションイベント＋共通ハンドラ追加
+  - UI: 検知シミュレーションボタン追加
+  - 通知: SnackBar/ダイアログ表示
+  - サウンド: アラート音再生（audioplayers）
+  - ハイライト: 一時的な背景色変更（黄色）
+- バックエンド: 変更なし（既存APIを利用）
+
+## 非スコープ
+- SSE/WebSocket実装（将来拡張として残す）
+- バックエンドの疑似検知API
+- 多端末同期・リアルタイム受信
+
+## アーキテクチャ設計
+
+### 共通ハンドラパターン
+```
+┌─────────────────────────────────────┐
+│  SimulateIncidentDetected (今回)    │
+│  IncidentDetectedReceived (将来)    │
+└──────────────┬──────────────────────┘
+               │
+               ▼
+      ┌────────────────────┐
+      │ _handleDetected()  │ ← 共通ハンドラ
+      │  (共通処理)         │
+      └────────────────────┘
+               │
+               ├─ updateIncidentStatus (resolved → open)
+               ├─ 一覧再フェッチ
+               ├─ highlightedItemId設定
+               ├─ SnackBar表示
+               ├─ アラート音再生
+               └─ 3秒後にハイライト解除
+```
+
+## フェーズ分割
+
+### Phase 1: BLoC拡張（共通ハンドラ実装）
+**目的**: 異常検知処理の共通ロジックを実装
+
+**変更ファイル**:
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_event.dart`
+  - `SimulateIncidentDetected` イベント追加
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_state.dart`
+  - `ViewScreenLoaded` に `highlightedItemId` フィールド追加
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart`
+  - `_handleDetected()` 共通ハンドラ実装
+  - `_onSimulateIncidentDetected()` ハンドラ追加
+
+**処理フロー**:
+1. 対象インシデント選定（指定ID or resolvedの先頭）
+2. `updateIncidentStatus(id, IncidentStatus.open, 'detected')`
+   - **この呼び出しで以下のDB更新が実行されます**:
+     - `incidents.status` を 'open' に更新（PATCH /api/v2/incidents/:id）
+     - `actions` テーブルに新規レコード追加（POST /api/v2/incidents/:id/actions）
+       - action_type: 'detected'
+       - progress: 'in_progress'
+       - start_at: 現在時刻
+     - `incidents.updated_at` が自動更新
+3. 成功後、一覧再フェッチ（GET /api/v2/incidents）
+4. `highlightedItemId` 設定
+5. 3秒後にタイマーでハイライト解除
+
+**DB更新の詳細**:
+- フロントエンドは既存の `updateIncidentStatus` UseCase/Repository を利用
+- バックエンドの既存API（PATCH + POST）が以下を実行:
+  ```sql
+  -- incidents テーブル更新
+  UPDATE incidents 
+  SET status = 'open', updated_at = NOW() 
+  WHERE id = :incident_id;
+  
+  -- actions テーブル追加
+  INSERT INTO actions (incident_id, action_type, progress, start_at, created_at)
+  VALUES (:incident_id, 'detected', 'in_progress', NOW(), NOW());
+  ```
+
+### Phase 2: UI拡張（ボタン＋ハイライト）
+**目的**: カード単位（カメラ単位）でシミュレーションを発火できるUI
+
+**変更ファイル**:
+- `frontend/lib/features/view_screen/domain/entities/incident_item.dart`
+  - `cameraId` フィールド追加
+- `frontend/lib/features/view_screen/infrastructure/repositories/view_screen_repository.dart`
+  - API の `camera_id` を `IncidentItem.cameraId` にマッピング
+- `frontend/lib/features/view_screen/presentation/widgets/molecules/incident_item_card.dart`
+  - `isHighlighted` プロパティ追加
+  - 背景色を `Colors.yellow.shade100` に変更
+  - カード右上に開発用シミュレーションボタン追加（kDebugMode時のみ表示）
+
+**UI配置**:
+```dart
+// incident_item_card.dart
+Stack(
+  children: [
+    // 既存カード本体
+    Container(
+      decoration: BoxDecoration(
+        color: isHighlighted ? Colors.yellow.shade100 : Colors.white,
+        // ...
+      ),
+      // ...
+    ),
+    // 開発用シミュレーションボタン（カード右上）
+    if (kDebugMode)
+      Positioned(
+        top: 4,
+        right: 4,
+        child: IconButton(
+          icon: const Icon(Icons.videocam_outlined, size: 18),
+          tooltip: 'このカメラで検知をシミュレーション',
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          onPressed: () {
+            context.read<ViewScreenBloc>().add(
+              SimulateIncidentDetected(
+                incidentId: item.id,
+                cameraId: item.cameraId,
+              ),
+            );
+          },
+        ),
+      ),
+  ],
+)
+```
+
+### Phase 3: 通知＋サウンド
+**目的**: ユーザーへの視覚・聴覚フィードバック
+
+**変更ファイル**:
+- `frontend/pubspec.yaml`
+  - `audioplayers: ^5.0.0` 追加
+  - `assets: - assets/sounds/alert.mp3` 追加
+- `frontend/assets/sounds/alert.mp3` (新規作成)
+- `frontend/lib/features/view_screen/presentation/pages/view_screen_page.dart`
+  - BlocListener で成功時に SnackBar 表示
+  - AudioPlayer でサウンド再生
+
+**通知実装**:
+```dart
+BlocListener<ViewScreenBloc, ViewScreenState>(
+  listener: (context, state) {
+    if (state is ViewScreenLoaded && state.highlightedItemId != null) {
+      // SnackBar表示
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('異常検知を受信しました')),
+      );
+      // サウンド再生
+      final player = AudioPlayer();
+      player.play(AssetSource('sounds/alert.mp3'));
+    }
+  },
+)
+```
+
+### Phase 4: テスト
+**目的**: 動作保証とリグレッション防止
+
+**テストケース**:
+1. `SimulateIncidentDetected` → `updateIncidentStatus` 呼び出し確認
+2. 成功後に一覧再フェッチ確認
+3. `highlightedItemId` 設定→解除のタイミング確認
+4. 既存テストの影響確認（Equatable props調整）
+
+**変更ファイル**:
+- `frontend/test/features/view_screen/presentation/blocs/view_screen_bloc_test.dart`
+  - シミュレーション経路のテスト追加
+
+### Phase 5: 将来拡張の準備
+**目的**: SSE/WebSocket連携への拡張ポイント明示
+
+**拡張ポイント**:
+```dart
+// 将来追加するイベント（今回は実装しない）
+class IncidentDetectedReceived extends ViewScreenEvent {
+  final String incidentId;
+  final Map<String, dynamic> metadata;
+  const IncidentDetectedReceived({
+    required this.incidentId,
+    required this.metadata,
+  });
+}
+
+// 同じ共通ハンドラを呼び出す
+Future<void> _onIncidentDetectedReceived(
+  IncidentDetectedReceived event,
+  Emitter<ViewScreenState> emit,
+) async {
+  await _handleDetected(event.incidentId, emit);
+}
+```
+
+## 実装詳細
+
+### BLoCイベント定義
+```dart
+// view_screen_event.dart
+class SimulateIncidentDetected extends ViewScreenEvent {
+  final String incidentId;  // 対象インシデントID（必須）
+  final String cameraId;    // 対象カメラID（必須）
+  
+  const SimulateIncidentDetected({
+    required this.incidentId,
+    required this.cameraId,
+  });
+  
+  @override
+  List<Object?> get props => [incidentId, cameraId];
+}
+```
+
+### BLoC状態拡張
+```dart
+// view_screen_state.dart
+class ViewScreenLoaded extends ViewScreenState {
+  final List<IncidentItem> items;
+  final String? highlightedItemId; // 追加
+  
+  const ViewScreenLoaded({
+    required this.items,
+    this.highlightedItemId,
+  });
+  
+  @override
+  List<Object?> get props => [items, highlightedItemId];
+}
+```
+
+### 共通ハンドラ実装
+```dart
+// view_screen_bloc.dart
+Future<void> _handleDetected(
+  String incidentId,
+  String cameraId,
+  Emitter<ViewScreenState> emit,
+) async {
+  final current = state;
+  if (current is! ViewScreenLoaded) {
+    add(const LoadIncidentItems());
+    return;
+  }
+
+  // ターゲット選定（incidentId + cameraId で検証）
+  final target = current.items.firstWhere(
+    (x) => x.id == incidentId && x.cameraId == cameraId,
+    orElse: () => throw Exception(
+      'Incident not found: id=$incidentId, cameraId=$cameraId'
+    ),
+  );
+  
+  // 冪等性: 既に open/monitoring の場合はDB更新をスキップ
+  if (target.status == IncidentStatus.open || 
+      target.status == IncidentStatus.inProgress) {
+    // UI通知とハイライトのみ実施
+    emit(ViewScreenLoaded(
+      items: current.items,
+      highlightedItemId: target.id,
+    ));
+    
+    // 3秒後に解除
+    Future.delayed(const Duration(seconds: 3), () {
+      final s = state;
+      if (s is ViewScreenLoaded && s.highlightedItemId == target.id) {
+        emit(ViewScreenLoaded(items: s.items, highlightedItemId: null));
+      }
+    });
+    
+    // ログ出力
+    print('[SimulateDetection] Already active: '
+          'incidentId=$incidentId, cameraId=$cameraId, status=${target.status}');
+    return;
+  }
+
+  // 更新中状態
+  emit(ViewScreenUpdating(
+    items: current.items,
+    updatingItemId: target.id,
+  ));
+
+  // ステータス更新（resolved → open）
+  // ログ出力
+  print('[SimulateDetection] Updating status: '
+        'incidentId=$incidentId, cameraId=$cameraId, '
+        'from=${target.status} to=open');
+  
+  final result = await repository.updateIncidentStatus(
+    id: target.id,
+    newStatus: IncidentStatus.open,
+    actionType: 'detected_camera', // カメラ由来を示す
+  );
+
+  await result.fold<Future<void>>(
+    (failure) async {
+      emit(ViewScreenLoaded(items: current.items));
+      emit(ViewScreenError(message: failure.message));
+      emit(ViewScreenLoaded(items: current.items));
+    },
+    (updated) async {
+      // 一覧再フェッチ
+      final refreshResult = await getIncidentItemsUseCase();
+      
+      await refreshResult.fold<Future<void>>(
+        (failure) async {
+          emit(ViewScreenLoaded(items: current.items));
+          emit(ViewScreenError(message: failure.message));
+          emit(ViewScreenLoaded(items: current.items));
+        },
+        (freshItems) async {
+          // ハイライト付与
+          emit(ViewScreenLoaded(
+            items: freshItems,
+            highlightedItemId: target.id,
+          ));
+          
+          // 3秒後に解除
+          Future.delayed(const Duration(seconds: 3), () {
+            final s = state;
+            if (s is ViewScreenLoaded && s.highlightedItemId == target.id) {
+              emit(ViewScreenLoaded(
+                items: s.items,
+                highlightedItemId: null,
+              ));
+            }
+          });
+        },
+      );
+    },
+  );
+}
+
+Future<void> _onSimulateIncidentDetected(
+  SimulateIncidentDetected event,
+  Emitter<ViewScreenState> emit,
+) async {
+  await _handleDetected(event.incidentId, event.cameraId, emit);
+}
+```
+
+### IncidentItem拡張
+```dart
+// incident_item.dart
+class IncidentItem extends Equatable {
+  final String id;
+  final String cameraId;  // 追加
+  final IncidentStatus status;
+  final String type;
+  final DateTime detectedAt;
+  final String personName;
+  final String roomNumber;
+  final bool isAlertActive;
+
+  const IncidentItem({
+    required this.id,
+    required this.cameraId,  // 追加
+    required this.status,
+    required this.type,
+    required this.detectedAt,
+    required this.personName,
+    required this.roomNumber,
+    required this.isAlertActive,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        cameraId,  // 追加
+        status,
+        type,
+        detectedAt,
+        personName,
+        roomNumber,
+        isAlertActive,
+      ];
+}
+```
+
+### カードハイライト実装
+```dart
+// incident_item_card.dart
+class IncidentItemCard extends StatelessWidget {
+  final IncidentItem item;
+  final bool isHighlighted; // 追加
+  
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: isHighlighted 
+            ? Colors.yellow.shade100 
+            : Colors.white,
+        // ...
+      ),
+      // ...
+    );
+  }
+}
+```
+
+## 受入れ条件（Acceptance Criteria）
+- [ ] **カード単位のボタン配置**:
+  - [ ] 各カード右上に開発用シミュレーションボタンが表示される（kDebugMode時のみ）
+  - [ ] ボタン押下で該当カードの incidentId + cameraId が BLoC に渡される
+- [ ] **cameraId のデータフロー**:
+  - [ ] API の `camera_id` が IncidentItem.cameraId にマッピングされる
+  - [ ] BLoC イベントで incidentId + cameraId を受け取る
+- [ ] **冪等性**:
+  - [ ] 既に open/monitoring のカードに対してはDB更新をスキップ
+  - [ ] UI通知とハイライトのみ実施（ログ出力あり）
+- [ ] **ステータス遷移（resolved → open）**:
+  - [ ] 対象インシデントが resolved → open に更新される
+  - [ ] `incidents.status` が 'open' に更新される
+  - [ ] `incidents.updated_at` が更新される
+  - [ ] `actions` テーブルに新規レコードが追加される（action_type='detected_camera'）
+- [ ] **UI反映**:
+  - [ ] 一覧が再フェッチされ、「異常検知一覧」に再配置される
+  - [ ] 対象カード背景が3秒間黄色にハイライトされる
+  - [ ] SnackBarで「異常検知を受信しました（カメラID: xxx）」と表示される
+  - [ ] アラート音が再生される
+- [ ] **ログ出力**:
+  - [ ] シミュレーション実行時に incidentId/cameraId/status をログ出力
+- [ ] 既存テストが全てパスする
+
+## リスクと緩和策
+- **Equatable比較の影響**: highlightedItemId追加により既存テストが失敗する可能性
+  - 緩和策: props順序を調整、テストを追随修正
+- **サウンド再生の制約**: Web版はユーザー操作起点が必要
+  - 緩和策: ボタン押下起点なので問題なし。将来Push受信時は視覚通知を優先
+- **タイマーのメモリリーク**: BLoC破棄時にタイマーが残る可能性
+  - 緩和策: state比較で対象IDが一致する場合のみ解除
+
+## 変更ファイル一覧（予定）
+### 新規作成
+- `frontend/assets/sounds/alert.mp3`
+
+### 更新
+- `frontend/pubspec.yaml`
+- `frontend/lib/features/view_screen/domain/entities/incident_item.dart` ← cameraId追加
+- `frontend/lib/features/view_screen/infrastructure/repositories/view_screen_repository.dart` ← camera_id マッピング
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_event.dart`
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_state.dart`
+- `frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart`
+- `frontend/lib/features/view_screen/presentation/widgets/molecules/incident_item_card.dart` ← カード右上にボタン追加
+- `frontend/test/features/view_screen/presentation/blocs/view_screen_bloc_test.dart`
+- 既存テスト全般（IncidentItem の props 変更に追随）
+
+## タイムライン（目安）
+- Phase 1（BLoC拡張）: 0.5日
+- Phase 2（UI拡張）: 0.5日
+- Phase 3（通知＋サウンド）: 0.5日
+- Phase 4（テスト）: 0.5日
+- Phase 5（ドキュメント）: 0.5日
+
+## 将来拡張（本番Push連携）
+本実装完了後、以下の手順でSSE/WebSocket連携へ拡張可能：
+
+1. **SSE/WebSocket Adapter追加**
+   - `ViewScreenNotificationService` 実装
+   - `/api/v2/stream/incidents` を購読
+
+2. **BLoCイベント追加**
+   - `IncidentDetectedReceived` イベント追加
+   - 同じ `_handleDetected()` を呼び出す
+
+3. **バックエンド拡張**
+   - SSEエンドポイント実装
+   - 疑似検知API（開発用）追加
+
+4. **置換不要な部分**
+   - UI（ボタン・ハイライト・通知）
+   - 共通ハンドラ（`_handleDetected`）
+   - テスト（シミュレーション経路は開発用として残す）

--- a/sample-project/frontend/lib/features/view_screen/domain/entities/incident_item.dart
+++ b/sample-project/frontend/lib/features/view_screen/domain/entities/incident_item.dart
@@ -5,6 +5,7 @@ import 'incident_status.dart';
 class IncidentItem extends Equatable {
   const IncidentItem({
     required this.id,
+    required this.cameraId,
     required this.roomBedNumber,
     required this.personName,
     required this.detectionType,
@@ -12,7 +13,6 @@ class IncidentItem extends Equatable {
     this.pictureAtDetection,
     this.pictureBeforeDetection,
     this.detectedAt,
-    this.cameraId,
     this.isAlertActive = true,
   });
 
@@ -40,8 +40,8 @@ class IncidentItem extends Equatable {
   /// 検知日時
   final DateTime? detectedAt;
 
-  /// カメラID
-  final String? cameraId;
+  /// カメラID（必須）
+  final String cameraId;
 
   /// アラート稼働状態（true: 稼働中, false: 停止中）
   final bool isAlertActive;
@@ -59,6 +59,7 @@ class IncidentItem extends Equatable {
   /// コピーメソッド
   IncidentItem copyWith({
     String? id,
+    String? cameraId,
     String? roomBedNumber,
     String? personName,
     String? detectionType,
@@ -66,11 +67,11 @@ class IncidentItem extends Equatable {
     String? pictureAtDetection,
     String? pictureBeforeDetection,
     DateTime? detectedAt,
-    String? cameraId,
     bool? isAlertActive,
   }) {
     return IncidentItem(
       id: id ?? this.id,
+      cameraId: cameraId ?? this.cameraId,
       roomBedNumber: roomBedNumber ?? this.roomBedNumber,
       personName: personName ?? this.personName,
       detectionType: detectionType ?? this.detectionType,
@@ -79,7 +80,6 @@ class IncidentItem extends Equatable {
       pictureBeforeDetection:
           pictureBeforeDetection ?? this.pictureBeforeDetection,
       detectedAt: detectedAt ?? this.detectedAt,
-      cameraId: cameraId ?? this.cameraId,
       isAlertActive: isAlertActive ?? this.isAlertActive,
     );
   }

--- a/sample-project/frontend/lib/features/view_screen/infrastructure/repositories/view_screen_repository.dart
+++ b/sample-project/frontend/lib/features/view_screen/infrastructure/repositories/view_screen_repository.dart
@@ -109,8 +109,15 @@ class ViewScreenRepository implements IViewScreenRepository {
     // 異常姿勢（検知タイプ）の取得
     String detectionType = data['type'] as String? ?? '臥床';
 
+    // カメラIDの取得（必須）
+    // APIは camera_id または cameraId のいずれかで返す可能性があるため両方チェック
+    String cameraId = (data['cameraId'] as String?) ?? 
+                      (data['camera_id'] as String?) ?? 
+                      'unknown-camera';
+
     return IncidentItem(
       id: data['id'] as String,
+      cameraId: cameraId,
       roomBedNumber: roomBedNumber,
       personName: personName,
       detectionType: detectionType,
@@ -118,7 +125,6 @@ class ViewScreenRepository implements IViewScreenRepository {
       pictureAtDetection: pictureAtDetection,
       pictureBeforeDetection: pictureBeforeDetection,
       detectedAt: detectedAt,
-      cameraId: data['cameraId'] as String?,
       isAlertActive: data['isAlertActive'] as bool? ?? true, // APIから取得、デフォルトは稼働中
     );
   }

--- a/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart
+++ b/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../application/usecases/get_incident_items_usecase.dart';
 import '../../../application/usecases/update_incident_status_usecase.dart';
+import '../../../domain/entities/incident_status.dart';
 import '../../../domain/repositories/i_view_screen_repository.dart';
 import 'view_screen_event.dart';
 import 'view_screen_state.dart';
@@ -20,6 +22,7 @@ class ViewScreenBloc extends Bloc<ViewScreenEvent, ViewScreenState> {
     on<RefreshIncidentItems>(_onRefreshIncidentItems);
     on<UpdateIncidentStatus>(_onUpdateIncidentStatus);
     on<ToggleAlertStatus>(_onToggleAlertStatus);
+    on<SimulateIncidentDetected>(_onSimulateIncidentDetected);
   }
 
   /// インシデントアイテム一覧を読み込む
@@ -148,6 +151,123 @@ class ViewScreenBloc extends Bloc<ViewScreenEvent, ViewScreenState> {
           (freshItems) async {
             // 最新の一覧で状態を更新
             emit(ViewScreenLoaded(items: freshItems));
+          },
+        );
+      },
+    );
+  }
+
+  /// 異常検知をシミュレーション（開発用）
+  Future<void> _onSimulateIncidentDetected(
+    SimulateIncidentDetected event,
+    Emitter<ViewScreenState> emit,
+  ) async {
+    await _handleDetected(event.incidentId, event.cameraId, emit);
+  }
+
+  /// 異常検知処理の共通ハンドラ（シミュレーション＋将来のPush受信で共用）
+  Future<void> _handleDetected(
+    String incidentId,
+    String cameraId,
+    Emitter<ViewScreenState> emit,
+  ) async {
+    final current = state;
+    if (current is! ViewScreenLoaded) {
+      add(const LoadIncidentItems());
+      return;
+    }
+
+    // ターゲット選定（incidentId + cameraId で検証）
+    final targetIndex = current.items.indexWhere(
+      (x) => x.id == incidentId && x.cameraId == cameraId,
+    );
+
+    if (targetIndex == -1) {
+      // 対象が見つからない場合はログ出力して終了
+      print('[SimulateDetection] Incident not found: '
+            'incidentId=$incidentId, cameraId=$cameraId');
+      emit(ViewScreenLoaded(items: current.items));
+      emit(ViewScreenError(
+        message: 'インシデントが見つかりません (ID: $incidentId, Camera: $cameraId)',
+      ));
+      emit(ViewScreenLoaded(items: current.items));
+      return;
+    }
+
+    final target = current.items[targetIndex];
+
+    // 冪等性: 既に open/inProgress の場合はDB更新をスキップ
+    if (target.status == IncidentStatus.unhandled ||
+        target.status == IncidentStatus.inProgress) {
+      // UI通知とハイライトのみ実施
+      emit(ViewScreenLoaded(
+        items: current.items,
+        highlightedItemId: target.id,
+      ));
+
+      // 3秒後に解除
+      Timer(const Duration(seconds: 3), () {
+        final s = state;
+        if (s is ViewScreenLoaded && s.highlightedItemId == target.id) {
+          emit(ViewScreenLoaded(items: s.items, highlightedItemId: null));
+        }
+      });
+
+      // ログ出力
+      print('[SimulateDetection] Already active: '
+            'incidentId=$incidentId, cameraId=$cameraId, status=${target.status}');
+      return;
+    }
+
+    // 更新中状態
+    emit(ViewScreenUpdating(
+      items: current.items,
+      updatingItemId: target.id,
+    ));
+
+    // ステータス更新（resolved → open）
+    print('[SimulateDetection] Updating status: '
+          'incidentId=$incidentId, cameraId=$cameraId, '
+          'from=${target.status} to=open');
+
+    final params = UpdateStatusParams(
+      id: target.id,
+      newStatus: IncidentStatus.unhandled,
+      actionType: 'detected_camera',
+    );
+
+    final result = await updateIncidentStatusUseCase(params);
+
+    await result.fold<Future<void>>(
+      (failure) async {
+        emit(ViewScreenLoaded(items: current.items));
+        emit(ViewScreenError(message: failure.message));
+        emit(ViewScreenLoaded(items: current.items));
+      },
+      (updated) async {
+        // 一覧再フェッチ
+        final refreshResult = await getIncidentItemsUseCase();
+
+        await refreshResult.fold<Future<void>>(
+          (failure) async {
+            emit(ViewScreenLoaded(items: current.items));
+            emit(ViewScreenError(message: failure.message));
+            emit(ViewScreenLoaded(items: current.items));
+          },
+          (freshItems) async {
+            // ハイライト付与
+            emit(ViewScreenLoaded(
+              items: freshItems,
+              highlightedItemId: target.id,
+            ));
+
+            // 3秒後に解除
+            Timer(const Duration(seconds: 3), () {
+              final s = state;
+              if (s is ViewScreenLoaded && s.highlightedItemId == target.id) {
+                emit(ViewScreenLoaded(items: s.items, highlightedItemId: null));
+              }
+            });
           },
         );
       },

--- a/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_event.dart
+++ b/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_event.dart
@@ -48,3 +48,17 @@ class ToggleAlertStatus extends ViewScreenEvent {
   @override
   List<Object?> get props => [incidentId, isActive];
 }
+
+/// 異常検知をシミュレーションするイベント（開発用）
+class SimulateIncidentDetected extends ViewScreenEvent {
+  final String incidentId;
+  final String cameraId;
+
+  const SimulateIncidentDetected({
+    required this.incidentId,
+    required this.cameraId,
+  });
+
+  @override
+  List<Object?> get props => [incidentId, cameraId];
+}

--- a/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_state.dart
+++ b/sample-project/frontend/lib/features/view_screen/presentation/blocs/view_screen_bloc/view_screen_state.dart
@@ -22,8 +22,12 @@ class ViewScreenLoading extends ViewScreenState {
 /// データ読み込み成功
 class ViewScreenLoaded extends ViewScreenState {
   final List<IncidentItem> items;
+  final String? highlightedItemId;
 
-  const ViewScreenLoaded({required this.items});
+  const ViewScreenLoaded({
+    required this.items,
+    this.highlightedItemId,
+  });
 
   /// 異常検知中のアイテム（未対応 + 対応中）
   List<IncidentItem> get detectedItems {
@@ -48,7 +52,7 @@ class ViewScreenLoaded extends ViewScreenState {
   }
 
   @override
-  List<Object?> get props => [items];
+  List<Object?> get props => [items, highlightedItemId];
 }
 
 /// エラー状態

--- a/sample-project/frontend/lib/features/view_screen/presentation/pages/view_screen_page.dart
+++ b/sample-project/frontend/lib/features/view_screen/presentation/pages/view_screen_page.dart
@@ -96,6 +96,9 @@ class _ViewScreenPageState extends State<ViewScreenPage> {
             final noDetectionItems = state is ViewScreenLoaded
                 ? state.noDetectionItems
                 : items.where((item) => !item.isDetected).toList();
+            final highlightedItemId = state is ViewScreenLoaded
+                ? state.highlightedItemId
+                : null;
 
             return RefreshIndicator(
               onRefresh: () async {
@@ -119,6 +122,7 @@ class _ViewScreenPageState extends State<ViewScreenPage> {
                       _buildGridView(
                         context,
                         detectedItems,
+                        highlightedItemId,
                         (item) => item, // アクションボタンは各カード内で処理
                       ),
                       const SizedBox(height: 16),
@@ -134,6 +138,7 @@ class _ViewScreenPageState extends State<ViewScreenPage> {
                       _buildGridView(
                         context,
                         noDetectionItems,
+                        highlightedItemId,
                         (item) => item, // アラート切替ボタンを表示
                       ),
                     ],
@@ -233,6 +238,7 @@ class _ViewScreenPageState extends State<ViewScreenPage> {
   Widget _buildGridView(
     BuildContext context,
     List items,
+    String? highlightedItemId,
     Function(dynamic)? onActionButtonPressed,
   ) {
     // レスポンシブ対応：画面幅に応じてカラム数を調整（最大5列）
@@ -258,6 +264,7 @@ class _ViewScreenPageState extends State<ViewScreenPage> {
             final item = items[index];
             return IncidentItemCard(
               item: item,
+              isHighlighted: highlightedItemId == item.id,
               onTap: () => _showIncidentDetail(context, item),
               onActionButtonPressed: onActionButtonPressed != null
                   ? (actionType) => _handleAction(context, item, actionType)

--- a/sample-project/frontend/lib/features/view_screen/presentation/widgets/molecules/incident_item_card.dart
+++ b/sample-project/frontend/lib/features/view_screen/presentation/widgets/molecules/incident_item_card.dart
@@ -1,6 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../domain/entities/incident_item.dart';
 import '../../../domain/entities/incident_status.dart';
+import '../../blocs/view_screen_bloc/view_screen_bloc.dart';
+import '../../blocs/view_screen_bloc/view_screen_event.dart';
 import '../atoms/status_badge.dart';
 
 /// インシデントアイテムカード（Molecule）
@@ -9,12 +13,14 @@ class IncidentItemCard extends StatefulWidget {
   final IncidentItem item;
   final VoidCallback? onTap;
   final Function(String actionType)? onActionButtonPressed;
+  final bool isHighlighted;
 
   const IncidentItemCard({
     super.key,
     required this.item,
     this.onTap,
     this.onActionButtonPressed,
+    this.isHighlighted = false,
   });
 
   @override
@@ -26,21 +32,23 @@ class _IncidentItemCardState extends State<IncidentItemCard> {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: EdgeInsets.zero,
-      elevation: 3,
-      color: Colors.white,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: _getBorderColor(),
-          width: 1,
-        ),
-      ),
-      child: InkWell(
-        onTap: widget.onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Column(
+    return Stack(
+      children: [
+        Card(
+          margin: EdgeInsets.zero,
+          elevation: 3,
+          color: widget.isHighlighted ? Colors.yellow.shade100 : Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(
+              color: _getBorderColor(),
+              width: 1,
+            ),
+          ),
+          child: InkWell(
+            onTap: widget.onTap,
+            borderRadius: BorderRadius.circular(12),
+            child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // ヘッダー（部屋番号 + 見守り対象者名 + 患者ID + ステータスバッジ）
@@ -144,14 +152,48 @@ class _IncidentItemCardState extends State<IncidentItemCard> {
               ),
             ),
 
-            // アクションボタン
-            Padding(
-              padding: const EdgeInsets.all(12),
-              child: _buildActionButtons(),
-            ),
-          ],
+              // アクションボタン
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: _buildActionButtons(),
+              ),
+            ],
+          ),
         ),
       ),
+      // 開発用シミュレーションボタン（kDebugMode時、かつ検知なしのカードのみ表示）
+      if (kDebugMode && widget.item.status == IncidentStatus.noDetection)
+        Positioned(
+          top: 4,
+          right: 4,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () {
+                context.read<ViewScreenBloc>().add(
+                      SimulateIncidentDetected(
+                        incidentId: widget.item.id,
+                        cameraId: widget.item.cameraId,
+                      ),
+                    );
+              },
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  color: Colors.orange.shade700.withValues(alpha: 0.9),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: const Icon(
+                  Icons.videocam_outlined,
+                  size: 16,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/sample-project/frontend/lib/main.dart
+++ b/sample-project/frontend/lib/main.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:mamoai/features/incident_history/presentation/pages/incident_history_page.dart';
+import 'package:mamoai/features/view_screen/di/view_screen_injection.dart';
+import 'package:mamoai/features/view_screen/presentation/pages/view_screen_page_wrapper.dart';
 
 void main() {
+  // ViewScreen機能の依存性注入（Mockデータを使用）
+  setupViewScreenDependencies(useMockData: true);
+  
   runApp(const MyApp());
 }
 
@@ -11,12 +15,12 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'MamoAI - 履歴画面',
+      title: 'MamoAI - ビュー画面',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
-      home: const IncidentHistoryPage(),
+      home: const ViewScreenPageWrapper(),
     );
   }
 }


### PR DESCRIPTION
## Note (if necessary)
- このPRでのDBスキーマ変更はありません。
- フロントエンドは Debug モードを想定。シミュレーションボタン（📹）は noDetection のカードにのみ表示されます。

## Description
- 異常検知のドライバを、異常検知されていないデータを対象に追加。カード上のボタンを押下で反映
- 表示条件を「kDebugMode かつ status == noDetection」に設定
- 影響範囲: フロントエンドのみ。バックエンド API 契約の変更はありません。
- BLoCのロジックは実装済み。バックエンドの異常通知の実装やWebSocket化は別途
- 変更ファイル:
  - frontend: features/view_screen/presentation/widgets/molecules/incident_item_card.dart
    - 変更: 📹ボタンの表示条件を kDebugMode && status == noDetection に限定
  - frontend: features/view_screen/presentation/blocs/view_screen_bloc/view_screen_bloc.dart
    - 変更: 3秒後のハイライト解除を Future.delayed + emit.isDone で安全化
